### PR TITLE
lec-imx8mp: weston-init: remove FHD restriction to allow 4K weston de…

### DIFF
--- a/recipes-graphics/wayland/weston-init/weston-adlink-imx8mp.ini
+++ b/recipes-graphics/wayland/weston-init/weston-adlink-imx8mp.ini
@@ -8,8 +8,6 @@ repaint-window=16
 #enable-overlay-view=1
 
 [shell]
-size=1920x1080
-
 background-image=/usr/share/weston/adlink.jpg
 background-type=scale
 


### PR DESCRIPTION
Display resolution of weston desktop is limited to FHD in weston-adlink-imx8mp.ini file.
Remove this limit to support 4K weston desktop.